### PR TITLE
Changes decode into verify in the simple decode example.

### DIFF
--- a/examples/02-simple-decode.php
+++ b/examples/02-simple-decode.php
@@ -7,4 +7,4 @@ $key = 'some-secret-for-hmac';
 $jwsString = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzb21lb25lQGV4YW1wbGUuY29tIiwiaWF0IjoiMTQwMjk5MzUzMSJ9.0lgcQRnj_Jour8MLdIc71hPjjLVcQAOtagKVD9soaqU';
 
 $jws = new \Gamegos\JWS\JWS();
-print_r($jws->decode($jwsString, $key));
+print_r($jws->verify($jwsString, $key));


### PR DESCRIPTION
The reason for this is that decode will manage to decode the string no matter the key given, while verify will decode only if the key is the same as the one used for encoding.
